### PR TITLE
feat: hello/client command support

### DIFF
--- a/src/nc_message.h
+++ b/src/nc_message.h
@@ -160,6 +160,7 @@ typedef enum msg_parse_result {
     ACTION( REQ_REDIS_ZSCORE )                                                                      \
     ACTION( REQ_REDIS_ZUNIONSTORE )                                                                 \
     ACTION( REQ_REDIS_ZSCAN)                                                                        \
+    ACTION( REQ_REDIS_HELLO )                                                                        \
     ACTION( REQ_REDIS_EVAL )                   /* redis requests - eval */                          \
     ACTION( REQ_REDIS_EVALSHA )                                                                     \
     ACTION( REQ_REDIS_PING )                   /* redis requests - ping/quit */                     \

--- a/src/nc_message.h
+++ b/src/nc_message.h
@@ -161,6 +161,7 @@ typedef enum msg_parse_result {
     ACTION( REQ_REDIS_ZUNIONSTORE )                                                                 \
     ACTION( REQ_REDIS_ZSCAN)                                                                        \
     ACTION( REQ_REDIS_HELLO )                                                                        \
+    ACTION( REQ_REDIS_CLIENT )                                                                        \
     ACTION( REQ_REDIS_EVAL )                   /* redis requests - eval */                          \
     ACTION( REQ_REDIS_EVALSHA )                                                                     \
     ACTION( REQ_REDIS_PING )                   /* redis requests - ping/quit */                     \

--- a/src/proto/nc_redis.c
+++ b/src/proto/nc_redis.c
@@ -251,6 +251,7 @@ redis_argn(struct msg *r)
     case MSG_REQ_REDIS_ZSCAN:
 
     case MSG_REQ_REDIS_HELLO:
+    case MSG_REQ_REDIS_CLIENT:
         return true;
 
     default:
@@ -883,6 +884,11 @@ redis_parse_req(struct msg *r)
 
                 if (str6icmp(m, 'z', 's', 'c', 'o', 'r', 'e')) {
                     r->type = MSG_REQ_REDIS_ZSCORE;
+                    break;
+                }
+
+                if (str6icmp(m, 'c', 'l', 'i', 'e', 'n', 't')) {
+                    r->type = MSG_REQ_REDIS_CLIENT;
                     break;
                 }
 

--- a/src/proto/nc_redis.c
+++ b/src/proto/nc_redis.c
@@ -249,6 +249,8 @@ redis_argn(struct msg *r)
     case MSG_REQ_REDIS_ZREVRANGEBYSCORE:
     case MSG_REQ_REDIS_ZUNIONSTORE:
     case MSG_REQ_REDIS_ZSCAN:
+
+    case MSG_REQ_REDIS_HELLO:
         return true;
 
     default:
@@ -768,6 +770,11 @@ redis_parse_req(struct msg *r)
 
                 if (str5icmp(m, 'p', 'f', 'a', 'd', 'd')) {
                     r->type = MSG_REQ_REDIS_PFADD;
+                    break;
+                }
+
+                if (str5icmp(m, 'h', 'e', 'l', 'l', 'o')) {
+                    r->type = MSG_REQ_REDIS_HELLO;
                     break;
                 }
 
@@ -2851,7 +2858,7 @@ redis_add_auth(struct context *ctx, struct conn *conn, struct server *server, in
     pool = server->owner;
     if (!pool->require_auth) {
         return NC_OK;
-    } 
+    }
 
     msg = msg_get(conn, true, conn->redis);
     if (msg == NULL) {


### PR DESCRIPTION
ref: https://github.com/redis/go-redis/issues/2616

Since upgrading the go-redis library to v9 twemproxy starts giving error possibly due to some unsupported commands (added in newer versions of redis) now being sent to twemproxy by the go-redis library.

This PR adds support for HELLO command, after adding the support for the command, twemproxy starts working.
